### PR TITLE
test(e2e): tests using spectron

### DIFF
--- a/e2e/app.e2e.ts
+++ b/e2e/app.e2e.ts
@@ -1,0 +1,71 @@
+const Application = require('spectron').Application;
+import { expect, should } from 'chai';
+let chai = require('chai');
+let chaiAsPromised = require('chai-as-promised');
+const path = require('path');
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('bterm launch', function() {
+  let timeOut = (mseconds) => this.timeout(mseconds);
+  timeOut(10000);
+
+  let electronPath = path.join(__dirname, '../..', 'node_modules', '.bin', 'electron');
+  beforeEach(() => {
+    this.app = new Application({
+      path: electronPath,
+      args: [path.join(__dirname, '..')],
+      env: { SPECTRON: true }
+    });
+    chaiAsPromised.transferPromiseness = this.app.transferPromiseness;
+    return this.app.start();
+  });
+
+  afterEach(() => {
+    timeOut(10000);
+    if (this.app && this.app.isRunning()) {
+      return this.app.stop();
+    }
+  });
+
+  it('should show an initial window', () => {
+    return this.app.client.waitUntilWindowLoaded()
+      .getWindowCount().should.eventually.equal(1);
+  });
+
+  it('should be visible', () => {
+    return this.app.client.waitUntilWindowLoaded()
+      .browserWindow.isVisible().should.eventually.be.true;
+  });
+
+  it('should not be minimized', () => {
+    return this.app.client.waitUntilWindowLoaded()
+      .browserWindow.isMinimized().should.eventually.be.false;
+  });
+
+  it('should be focused', () => {
+    return this.app.client.waitUntilWindowLoaded()
+      .browserWindow.isFocused().should.eventually.be.true;
+  });
+
+  it('should have a width', () => {
+    return this.app.client.waitUntilWindowLoaded()
+      .browserWindow.getBounds().should.eventually.have.property('width').and.be.above(0);
+  });
+
+  it('should have a height', () => {
+    return this.app.client.waitUntilWindowLoaded()
+      .browserWindow.getBounds().should.eventually.have.property('height').and.be.above(0);
+  });
+
+  it('should have the app title', () => {
+    return this.app.client.browserWindow.getTitle().should.eventually.equal('bterm');
+  });
+
+  it('should have the shell title', () => {
+    return this.app.client.getText('.title').should.eventually.equal('Shell');
+  });
+
+})
+

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "declaration": false,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "lib": [
+      "es2016",
+      "dom"
+    ],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "../dist/out-tsc-e2e",
+    "sourceMap": true,
+    "target": "es6",
+    "typeRoots": [
+      "../node_modules/@types"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "prebuild": "npm run clean",
     "postinstall": "electron-rebuild && install-app-deps",
     "dist": "npm run build && node ./scripts/index.js app",
-    "clean": "rimraf dist/ src/ngfactory lib/"
+    "clean": "rimraf dist/ src/ngfactory lib/",
+    "test:e2e": "tsc -p e2e && ./node_modules/mocha/bin/mocha dist/out-tsc-e2e/app.e2e.js"
   },
   "repository": {
     "type": "git",
@@ -50,9 +51,12 @@
     "@types/electron": "^1.4.35",
     "@types/electron-builder": "^2.0.29",
     "@types/fs-extra": "2.0.0",
+    "@types/jasmine": "^2.5.47",
     "@types/lodash": "^4.14.62",
     "@types/node": "^7.0.12",
     "@types/node-sass": "^3.10.32",
+    "chai": "^3.5.0",
+    "chai-as-promised": "^6.0.0",
     "chalk": "^1.1.3",
     "chokidar": "^1.6.1",
     "codelyzer": "^3.0.0-beta.4",
@@ -67,6 +71,7 @@
     "html-webpack-plugin": "^2.28.0",
     "json-loader": "^0.5.4",
     "lodash": "^4.17.4",
+    "mocha": "^3.3.0",
     "node-sass": "^4.5.2",
     "raw-loader": "^0.5.1",
     "rimraf": "^2.6.1",
@@ -75,6 +80,7 @@
     "rollup-plugin-progress": "^0.2.1",
     "rollup-plugin-typescript": "^0.8.1",
     "sass-loader": "^6.0.3",
+    "spectron": "^3.6.2",
     "style-loader": "^0.16.1",
     "tslint": "^5.1.0",
     "typescript": "2.2.2",


### PR DESCRIPTION
This PR will close https://github.com/bleenco/bterm/issues/15. Please note that there is 

`WARNING: the "timeoutsAsyncScript" command will be depcrecated soon. Please use a different command in order to avoid failures in your test after updating WebdriverIO.`

This is not related to our application code, just a warning that **timeoutsAsyncScript** will be deprecated thus we should use **timeouts** instead. More info [here](http://webdriver.io/api/protocol/timeoutsAsyncScript.html) 

I did not use arrow function in describe because of `this.timeout(10000);` if I did `this`  would not have .timeout()