### PR TITLE
fix(): droping a file/link now emits its url (closes #82)

### DIFF
--- a/e2e/app.e2e.ts
+++ b/e2e/app.e2e.ts
@@ -548,4 +548,13 @@ describe('bterm launch', function() {
       });
     }
 
+  it('should type the uri in terminal on will-navigate', () => {
+    let testString: string = '/path/to/blah/random.bleenco.test';
+    return this.app.client.waitUntilWindowLoaded()
+      .then(() => this.app.client.browserWindow.send('navigate', testString))
+      .then(() => wait(2000))
+      .then(() => this.app.client.getText('.terminal-instance'))
+      .then(text => expect(text).to.contain(testString));
+  });
+
 });

--- a/src/app/components/window-terminal/window-terminal.component.ts
+++ b/src/app/components/window-terminal/window-terminal.component.ts
@@ -34,7 +34,9 @@ export class WindowTerminalComponent implements OnInit {
 
     ipcRenderer.on('paste', () => this.paste());
     ipcRenderer.on('copy', () => this.copy());
-
+    ipcRenderer.on('navigate', (ev, url) => {
+      this.xterm.terminals[this.xterm.currentIndex].output.emit(url);
+    });
     this.initMenu();
 
     // auto-copy on selection

--- a/src/app/services/pty.service.ts
+++ b/src/app/services/pty.service.ts
@@ -15,26 +15,10 @@ export interface Process {
 export class PTYService {
   shell: string;
   args: string[];
-  user: any;
   path: string;
   processes: Process[];
 
   constructor(@Inject(ConfigService) private _config: ConfigService) {
-    this.user = os.userInfo({ encoding: 'utf8' });
-    switch (os.platform()) {
-      case 'win32':
-        this.shell = 'cmd.exe';
-        this.args = [];
-        break;
-      case 'darwin':
-        this.shell = 'login';
-        this.args = ['-fp', this.user.username];
-        break;
-      case 'linux':
-        this.shell = '/bin/bash';
-        this.args = [];
-        break;
-    }
     this.processes = [];
   }
 
@@ -44,7 +28,7 @@ export class PTYService {
         name: 'xterm-color',
         cols: 80,
         rows: 30,
-        cwd: os.homedir(),
+        cwd: process.cwd() || os.homedir(),
         env: process.env
       }),
       input: new EventEmitter<string>(),

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -79,6 +79,10 @@ app.on('browser-window-created', (e: Event, win: Electron.BrowserWindow) => {
   current.on('blur', () => unregisterShortcuts());
   current.on('focus', () => registerShortcuts(current));
   current.on('move', () => current.webContents.send('focusCurrent', true));
+  current.webContents.on('will-navigate', (ev: Electron.Event, url: string) => {
+    ev.preventDefault();
+    current.webContents.send('navigate', url);
+  });
 });
 
 app.on('browser-window-focus', (e: Event, win: Electron.BrowserWindow) => {


### PR DESCRIPTION
When dragging and dropping a resource (file or a link) into the terminal window it gets typed into the active terminal.

Also, in this update the CWD upon starting will be copied from the environment.