### PR TITLE
chore(): release 1.0.0 ZEN VIPER

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Fully customisable cross-platform terminal.
 Runs everywhere. MacOS, Linux or Windows.
 
 ## Download
-To download wisit
+To download visit
 [http://bterm.bleenco.io](http://bterm.bleenco.io) click the right installer depending on
 operating system you use.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bterm",
-  "version": "0.9.4",
+  "version": "1.0.0",
   "description": "bterm - Cross-Platform Terminal",
   "main": "electron.js",
   "scripts": {


### PR DESCRIPTION
Version bump and a typo fix for 1.0.0. "ZEN VIPER"